### PR TITLE
add container name gin_db in docker compose file

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -20,6 +20,7 @@ services:
       - gin-demo-stack
 
   mysql:
+    container_name: gin_db
     image: mysql:8.0
     ports:
       - ${EXPOSE_DB_PORT}:${DB_PORT}


### PR DESCRIPTION
I was facing some issue with database conntection when i run docker-compose up command

Currently in docker compose file their is no gin_db such things 
but gin_demo container trying to connect gin_db as a database while container name is mysql 
so i put this gin_db container name in compose file